### PR TITLE
Replace all occurances of '%streamer%' in open cmd

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -153,7 +153,7 @@ const ExtensionLayout = new Lang.Class({
 
   _execCmd:function(sender, event, streamer) {
     this.menu.close();
-    let cmd = OPENCMD.replace('%streamer%', streamer);
+    let cmd = OPENCMD.replace(new RegExp('%streamer%', 'g'), streamer);
     GLib.spawn_command_line_async(cmd);
   },
 


### PR DESCRIPTION
I'm using mpv and it's very useful for modifying player title with such command:
`livestreamer http://twitch.tv/%streamer% best -a "{filename} --title='twitch.tv/%streamer%'"`

Nice clear titles and ability to find stream window with "Window search provider" extension :wink: 