### PR TITLE
Add compatibility with gnome 3.34

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -311,9 +311,9 @@ const ExtensionLayout = GObject.registerClass(
       else {
         this.spacer.actor.show();
         // gather sizes
-        let sizes = menuItems.map((item) => item.get_size_info()).reduce(max_size_info, [0,0,0]);
+        let sizes = menuItems.map(get_size_info).reduce(max_size_info, [0,0,0]);
         // set sizes
-        menuItems.map((item) => item.apply_size_info(sizes));
+        menuItems.map((item) => apply_size_info(item, sizes));
       }
       this.layoutChanged = false;
     };
@@ -353,6 +353,20 @@ const ExtensionLayout = GObject.registerClass(
 
 function max_size_info(size_info1, size_info2) {
   return [Math.max(size_info1[0], size_info2[0]), Math.max(size_info1[1], size_info2[1]), Math.max(size_info1[2], size_info2[2])]
+}
+
+function get_size_info(item) {
+  return [item._layout.name.get_allocation_box().get_width(), item._layout.game.get_allocation_box().get_width(), item._layout.viewer_count.get_allocation_box().get_width()];
+}
+
+function apply_size_info(item, size_info) {
+  let viewer_count_size_diff = size_info[2] - item._layout.viewer_count.get_allocation_box().get_width();
+  item._layout.name.set_width(size_info[0]);
+  item._layout.game.set_width(size_info[1] + viewer_count_size_diff);
+  item._layout.viewer_count.set_width(size_info[2] - viewer_count_size_diff);
+  if ( item._layout.title ) {
+    item._layout.title.set_width(size_info[0] + size_info[1] + size_info[2] );
+  }
 }
 
 function init() {

--- a/menu_items.js
+++ b/menu_items.js
@@ -44,24 +44,6 @@ var StreamerMenuItem = class extends PopupMenu.PopupBaseMenuItem {
 
     this.actor.add(this._wrapBox);
   };
-
-  get_streamer() {
-    return this._streamer;
-  };
-
-  get_size_info() {
-    return [this._layout.name.get_allocation_box().get_width(), this._layout.game.get_allocation_box().get_width(), this._layout.viewer_count.get_allocation_box().get_width()];
-  };
-
-  apply_size_info(size_info) {
-    let viewer_count_size_diff = size_info[2] - this._layout.viewer_count.get_allocation_box().get_width();
-    this._layout.name.set_width(size_info[0]);
-    this._layout.game.set_width(size_info[1] + viewer_count_size_diff);
-    this._layout.viewer_count.set_width(size_info[2] - viewer_count_size_diff);
-    if ( this._layout.title ) {
-      this._layout.title.set_width(size_info[0] + size_info[1] + size_info[2] );
-    }
-  }
 }
 
 class NobodyMenuItem extends PopupMenu.PopupBaseMenuItem {


### PR DESCRIPTION
Extension fails in gnome 3.34 with the following error

`TypeError: item.get_size_info is not a function`

when updating the list of streams.

`PopupBaseMenuItem` changed from an ES6 class to a GObject class in gnome-shell 3.34 which apparently breaks inheritance. This can be fixed by using `GObject.registerClass` to handle the inheritance but this breaks compatibility with 3.32. Seeing as only 2 small methods are being added these can be converted to normal functions so it works with both 3.32 and 3.34.

`get_streamer` appears to be unused so was dropped.

Tested with Fedora 30 and 31.