### PR TITLE
3.30-helix oauth

### DIFF
--- a/api.js
+++ b/api.js
@@ -46,7 +46,7 @@ function load_json_async(httpSession, url, fun) {
   let oauth_token = get_token();
   message.requestHeaders.append('Client-ID', client_id);
   if (oauth_token) {
-    message.requestHeaders.append('Authorization', "OAuth " + oauth_token);
+    message.requestHeaders.append('Authorization', "Bearer " + oauth_token);
   }
   httpSession.queue_message(message, function(session, message) {
       let data = JSON.parse(message.response_body.data);

--- a/api.js
+++ b/api.js
@@ -14,27 +14,21 @@ const api_base = 'https://api.twitch.tv/helix/';
 const client_id = "1zat8h7je94boq5t88of6j09p41hg0";
 const oauth_receiver = imports.misc.extensionUtils.getCurrentExtension().path + "/oauth_receive.py"
 const oauth_token_path = GLib.get_user_cache_dir() + '/twitchlive-extension/oauth_token';
-var token_cache = undefined;
 
 /* OAuth */
 
 function trigger_oauth() {
-  token_cache = undefined;
   const url = "https://id.twitch.tv/oauth2/authorize?response_type=token&client_id=" + client_id + "&redirect_uri=http://localhost:8877&scope=";
   GLib.spawn_command_line_async("xdg-open " + url);
   GLib.spawn_sync(null, ["python3", oauth_receiver,  oauth_token_path], null, GLib.SpawnFlags.SEARCH_PATH, null);
 }
 
 function get_token() {
-  if (token_cache) {
-    return token_cache;
-  }
   var tokenfile = Gio.File.new_for_path(oauth_token_path);
   if (tokenfile.query_exists(null)) {
     let success, content, tag;
     [success, content, tag] = tokenfile.load_contents(null);
-    token_cache = ByteArray.toString(content);
-    return token_cache;
+    return ByteArray.toString(content);
   }
   return undefined;
 }

--- a/oauth_receive.py
+++ b/oauth_receive.py
@@ -1,3 +1,10 @@
+# This script is used to create tiny webserver that receives an OAuth callback
+# as GNOME does not provide a way for extensions to do that.
+# gnome-online-accounts has no interface for that, neither does the shell.
+# This is minimal implementation for what is needed to do OpenAuth without a client secret
+# AUTHOR: Mario Wenzel
+# LICENSE: GPL3.0
+
 from http.server import *;
 from urllib.parse import *;
 import sys;

--- a/oauth_receive.py
+++ b/oauth_receive.py
@@ -1,7 +1,8 @@
 # This script is used to create tiny webserver that receives an OAuth callback
 # as GNOME does not provide a way for extensions to do that.
 # gnome-online-accounts has no interface for that, neither does the shell.
-# This is minimal implementation for what is needed to do OpenAuth without a client secret
+# This is minimal implementation for what is needed to do OpenAuth without a client secret.
+# We need the browser as the token is passed in the url fragment.
 # AUTHOR: Mario Wenzel
 # LICENSE: GPL3.0
 
@@ -25,14 +26,13 @@ class handler(BaseHTTPRequestHandler):
         print(self.path)
         if self.path == '/':
             # initial call from twitch
-            print(self.path)
-
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
 
             self.wfile.write(page.encode())
         elif self.path.startswith('/tokens'):
+            # our own call
             code = parse_qs(urlparse(self.path).query)['access_token'][0]
             open(sys.argv[1], 'w').write(code)
 

--- a/oauth_receive.py
+++ b/oauth_receive.py
@@ -1,0 +1,39 @@
+from http.server import *;
+from urllib.parse import *;
+import sys;
+import os.path;
+
+page = """<html>
+<head><title>Twitchlive GNOME Shell extension OAuth</title></head>
+<body><script>var tokens=document.location.hash.substring(1);
+document.write("<a href=\\"/tokens?" + tokens + "\\"> To finish OAuth-Process click here</a>");
+</script></body>
+"""
+
+class handler(BaseHTTPRequestHandler):
+    def log_requests(self):
+        pass
+
+    def do_GET(self):
+        print(self.path)
+        if self.path == '/':
+            # initial call from twitch
+            print(self.path)
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+
+            self.wfile.write(page.encode())
+        elif self.path.startswith('/tokens'):
+            code = parse_qs(urlparse(self.path).query)['access_token'][0]
+            open(sys.argv[1], 'w').write(code)
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+
+            self.wfile.write(b"Thank You. You can close this page.")
+            sys.exit(0)
+
+HTTPServer(('', 8877), handler).serve_forever()

--- a/prefs.xml
+++ b/prefs.xml
@@ -120,6 +120,11 @@
 								<property name="label" translatable="yes">Import from twitch user</property>
 							</object>
 						</child>
+						<child>
+							<object class="GtkButton" id="authenticate_oauth">
+								<property name="label" translatable="yes">OAuth authentication</property>
+							</object>
+						</child>
 						</object>
 					</child>
 


### PR DESCRIPTION
Cherry-pick oauth support into 3.30 branch (since this is the most recent version available on Debian Buster).

(*Possibly* the solution for #70)