### PR TITLE
fixed Soup.SessionAsync is not a constructor

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -84,13 +84,13 @@ const ExtensionLayout = GObject.registerClass(
       this.firstRun = true, // Avoids notifications on first run
       this.timer = { view: 0, update: 0, settings: 0 };
       this.settings = new Gio.Settings({ settings_schema: schema });
-      this._httpSession = new Soup.SessionAsync();
+      this._httpSession = Soup.Session.new();
       this.layoutChanged = false;
       this.streamer_rotation = 0;
 
 
       // Make soup use default system proxy if configured
-      Soup.Session.prototype.add_feature.call(this._httpSession, new Soup.ProxyResolverDefault());
+      // Soup.Session.prototype.add_feature.call(this._httpSession, new Soup.ProxyResolverDefault());
 
       this._box = new St.BoxLayout();
       this.add_child(this._box);

--- a/prefs.js
+++ b/prefs.js
@@ -30,9 +30,9 @@ Gettext.bindtextdomain(domain, localeDir.get_path());
 const App = class {
 
   constructor() {
-    this._httpSession = new Soup.SessionAsync();
+    this._httpSession = Soup.Session.new();
     // Make soup use default system proxy if configured
-    Soup.Session.prototype.add_feature.call(this._httpSession, new Soup.ProxyResolverDefault());
+    // Soup.Session.prototype.add_feature.call(this._httpSession, new Soup.ProxyResolverDefault());
 
     Icons.init_icons();
 


### PR DESCRIPTION
- Closed
  - #82
  - #81
- I know nothing about gnome extension development and this is my first time touching gnome extension source code so couldn't get proxy to work :(

Referred doc:
- https://lazka.github.io/pgi-docs/Soup-2.4/classes/SessionAsync.html